### PR TITLE
Correct broken link

### DIFF
--- a/components/drawers.html
+++ b/components/drawers.html
@@ -4,7 +4,7 @@ title: Drawers
 ---
 
 <p class="c-paragraph">
-	Slide in menus, but "<a class="c-link" href="/components/c-menus/">menus</a>" was already taken so welcome to
+	Slide in menus, but "<a class="c-link" href="/components/menus/">menus</a>" was already taken so welcome to
 	drawers.
 </p>
 <h2 class="c-heading c-heading--medium">Basic Drawer</h2>


### PR DESCRIPTION
Link to menus takes you to `/components/c-menus/` where it should be `/components/menus/`