### PR TITLE
Nav light variation with c-nav--light

### DIFF
--- a/components/navs.html
+++ b/components/navs.html
@@ -92,3 +92,18 @@ title: Navs
         <span class="c-nav__item c-nav__item--right"><i class="fa fa-user"></i> Contact</span>
     </ul>
 </div>
+<h2 id="light-variation" class="c-heading c-heading--medium">Light variation</h2>
+<div class="u-letter-box--medium">
+    <ul class="c-nav c-nav--light c-nav--inline">
+        <li class="c-nav__item"><i class="fa fa-home"></i> Home</li>
+        <li class="c-nav__item"><i class="fa fa-star"></i> News</li>
+        <li class="c-nav__item c-nav__item--right"><i class="fa fa-user"></i> Contact</li>
+    </ul>
+</div>
+<div class="u-letter-box--medium">
+    <pre class="c-pre html"><code class="c-code c-code--multiline">&lt;ul class="c-nav c-nav--light">
+  &lt;li class="c-nav__item">Home&lt;/li>
+  &lt;li class="c-nav__item">News&lt;/li>
+  &lt;li class="c-nav__item c-nav__item--right">Contact&lt;/li>
+&lt;/ul></code></pre>
+</div>


### PR DESCRIPTION
I noticed the docs didn't have the light nav variation.  Happy to make copy changes if needed.

![2017-04-14 at 22 59](https://cloud.githubusercontent.com/assets/2206948/25057261/0dea4fa2-2166-11e7-8d5f-7b2c30e0bfbd.png)

Edit: cc @gregorypratt 
